### PR TITLE
Remove Unnecessary Post-Install Message

### DIFF
--- a/wannabe_bool.gemspec
+++ b/wannabe_bool.gemspec
@@ -19,12 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.platform              = Gem::Platform::RUBY
   spec.required_ruby_version = Gem::Requirement.new('>= 1.9.3')
-  spec.post_install_message  = %{
-  Wannabe Bool installed!
-  You have just gotten one more gem from a Brazilian Ruby Developer.
-  Enjoy it, Prodis.
-
-  }
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
I was surprised to see this post-install message in the bundler output when I included this gem in a project.

Many developers expect that a post-install message, when present, will include important information about a gem or a notice about breaking changes. Because the current message adds superfluous bundler output without providing any useful information, this commit removes it.