### PR TITLE
Add aliasing for .to_b method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can configure the result for invalid boolean string representations, using t
 There are 3 predefined behaviours available: to return `false` (default), `nil` or raise an `ArgumentError`:
 
 ```ruby
-# WannabeBool.invalid_value_behaviour = WannabeBool::InvalidValueBehaviour::False
+WannabeBool.invalid_value_behaviour = WannabeBool::InvalidValueBehaviour::False
 'wherever'.to_b # => false
 
 WannabeBool.invalid_value_behaviour = WannabeBool::InvalidValueBehaviour::Nil

--- a/lib/wannabe_bool.rb
+++ b/lib/wannabe_bool.rb
@@ -2,6 +2,7 @@ module WannabeBool; end
 
 require 'wannabe_bool/invalid_value_behaviour'
 require 'wannabe_bool/configuration'
+require 'wannabe_bool/aliasing'
 require 'wannabe_bool/boolean'
 require 'wannabe_bool/nil'
 require 'wannabe_bool/numeric'

--- a/lib/wannabe_bool/aliasing.rb
+++ b/lib/wannabe_bool/aliasing.rb
@@ -5,4 +5,8 @@ module WannabeBool::Aliasing
       alias_method :to_boolean, :to_b
     end
   end
+
+  def to_b
+    raise NotImplementedError
+  end
 end

--- a/lib/wannabe_bool/aliasing.rb
+++ b/lib/wannabe_bool/aliasing.rb
@@ -1,0 +1,8 @@
+module WannabeBool::Aliasing
+  def self.included base
+    base.class_eval do
+      alias_method :to_bool, :to_b
+      alias_method :to_boolean, :to_b
+    end
+  end
+end

--- a/lib/wannabe_bool/boolean.rb
+++ b/lib/wannabe_bool/boolean.rb
@@ -2,6 +2,9 @@ module WannabeBool::Boolean
   def to_b
     self
   end
+
+  alias_method 'to_boolean', 'to_b'
+  alias_method 'to_bool', 'to_b'  
 end
 
 class TrueClass

--- a/lib/wannabe_bool/boolean.rb
+++ b/lib/wannabe_bool/boolean.rb
@@ -3,8 +3,7 @@ module WannabeBool::Boolean
     self
   end
 
-  alias_method 'to_boolean', 'to_b'
-  alias_method 'to_bool', 'to_b'  
+  include WannabeBool::Aliasing
 end
 
 class TrueClass

--- a/lib/wannabe_bool/nil.rb
+++ b/lib/wannabe_bool/nil.rb
@@ -2,9 +2,8 @@ module WannabeBool::Nil
   def to_b
     false
   end
-
-  alias_method 'to_boolean', 'to_b'
-  alias_method 'to_bool', 'to_b'
+  
+  include WannabeBool::Aliasing
 end
 
 class NilClass

--- a/lib/wannabe_bool/nil.rb
+++ b/lib/wannabe_bool/nil.rb
@@ -2,6 +2,9 @@ module WannabeBool::Nil
   def to_b
     false
   end
+
+  alias_method 'to_boolean', 'to_b'
+  alias_method 'to_bool', 'to_b'
 end
 
 class NilClass

--- a/lib/wannabe_bool/numeric.rb
+++ b/lib/wannabe_bool/numeric.rb
@@ -2,6 +2,9 @@ module WannabeBool::Numeric
   def to_b
     !self.zero?
   end
+
+  alias_method 'to_boolean', 'to_b'
+  alias_method 'to_bool', 'to_b'
 end
 
 class Numeric

--- a/lib/wannabe_bool/numeric.rb
+++ b/lib/wannabe_bool/numeric.rb
@@ -3,8 +3,7 @@ module WannabeBool::Numeric
     !self.zero?
   end
 
-  alias_method 'to_boolean', 'to_b'
-  alias_method 'to_bool', 'to_b'
+  include WannabeBool::Aliasing
 end
 
 class Numeric

--- a/lib/wannabe_bool/string.rb
+++ b/lib/wannabe_bool/string.rb
@@ -9,9 +9,8 @@ module WannabeBool::String
 
     WannabeBool.invalid_value_behaviour.call
   end
-
-  alias_method 'to_boolean', 'to_b'
-  alias_method 'to_bool', 'to_b'  
+  
+  include WannabeBool::Aliasing
 end
 
 class String

--- a/lib/wannabe_bool/string.rb
+++ b/lib/wannabe_bool/string.rb
@@ -9,6 +9,9 @@ module WannabeBool::String
 
     WannabeBool.invalid_value_behaviour.call
   end
+
+  alias_method 'to_boolean', 'to_b'
+  alias_method 'to_bool', 'to_b'  
 end
 
 class String

--- a/lib/wannabe_bool/symbol.rb
+++ b/lib/wannabe_bool/symbol.rb
@@ -2,6 +2,9 @@ module WannabeBool::Symbol
   def to_b
     self.to_s.to_b
   end
+
+  alias_method 'to_boolean', 'to_b'
+  alias_method 'to_bool', 'to_b'  
 end
 
 class Symbol

--- a/lib/wannabe_bool/symbol.rb
+++ b/lib/wannabe_bool/symbol.rb
@@ -1,10 +1,9 @@
 module WannabeBool::Symbol
   def to_b
     self.to_s.to_b
-  end
-
-  alias_method 'to_boolean', 'to_b'
-  alias_method 'to_bool', 'to_b'  
+  end  
+  
+  include WannabeBool::Aliasing
 end
 
 class Symbol

--- a/spec/wannabe_bool/aliasing_spec.rb
+++ b/spec/wannabe_bool/aliasing_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe WannabeBool::Aliasing do
+  let(:anonymous_class) { Class.new { include WannabeBool::Aliasing } }
+
+  # When there is no to_b method on the parent class, 
+  # this module should raise NotImplementedError for all the three methods
+  describe '#to_b' do
+    it 'should raise NotImplementedError' do
+      expect{ anonymous_class.new.to_b }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#to_bool' do
+    it 'should raise NotImplementedError' do
+      expect{ anonymous_class.new.to_bool }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#to_boolean' do
+    it 'should raise NotImplementedError' do
+      expect{ anonymous_class.new.to_boolean }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/wannabe_bool/boolean_spec.rb
+++ b/spec/wannabe_bool/boolean_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe WannabeBool::Boolean do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be true }
+      it { expect(subject.to_boolean).to be subject.to_b }
+      it { expect(subject.to_bool).to be subject.to_b }      
     end
   end
 
@@ -12,6 +14,8 @@ RSpec.describe WannabeBool::Boolean do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be false }
+      it { expect(subject.to_boolean).to be subject.to_b }
+      it { expect(subject.to_bool).to be subject.to_b }      
     end
   end
 end

--- a/spec/wannabe_bool/boolean_spec.rb
+++ b/spec/wannabe_bool/boolean_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe WannabeBool::Boolean do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be true }
-      it { expect(subject.to_boolean).to be subject.to_b }
-      it { expect(subject.to_bool).to be subject.to_b }      
+    end
+
+    describe '#to_bool' do
+      it { expect(subject.to_bool).to be true }      
+    end
+
+    describe '#to_boolean' do
+      it { expect(subject.to_boolean).to be true }      
     end
   end
 
@@ -14,8 +20,14 @@ RSpec.describe WannabeBool::Boolean do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be false }
-      it { expect(subject.to_boolean).to be subject.to_b }
-      it { expect(subject.to_bool).to be subject.to_b }      
     end
+
+    describe '#to_bool' do
+      it { expect(subject.to_bool).to be false }      
+    end
+
+    describe '#to_boolean' do
+      it { expect(subject.to_boolean).to be false }      
+    end    
   end
 end

--- a/spec/wannabe_bool/nil_spec.rb
+++ b/spec/wannabe_bool/nil_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe WannabeBool::Nil do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be false }
-      it { expect(subject.to_boolean).to be subject.to_b }
-      it { expect(subject.to_bool).to be subject.to_b }
     end
+
+    describe '#to_bool' do
+      it { expect(subject.to_bool).to be false }
+    end
+
+    describe '#to_boolean' do
+      it { expect(subject.to_boolean).to be false }
+    end    
   end
 end

--- a/spec/wannabe_bool/nil_spec.rb
+++ b/spec/wannabe_bool/nil_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe WannabeBool::Nil do
 
     describe '#to_b' do
       it { expect(subject.to_b).to be false }
+      it { expect(subject.to_boolean).to be subject.to_b }
+      it { expect(subject.to_bool).to be subject.to_b }
     end
   end
 end

--- a/spec/wannabe_bool/numeric_spec.rb
+++ b/spec/wannabe_bool/numeric_spec.rb
@@ -1,18 +1,25 @@
 require 'bigdecimal'
 
 RSpec.describe WannabeBool::Numeric do
-  context Integer do
-    positives = (1..9)
-    negatives = (-9..-1)
-    
+  ZERO = 0.freeze
+  INTEGER_POSITIVES = (1..9).freeze
+  INTEGER_NEGATIVES = (-9..-1).freeze
+  FLOAT_ZERO = (0.0).freeze
+  FLOAT_POSITIVES = (Random.rand).freeze
+  FLOAT_NEGATIVES = (Random.rand * -1).freeze
+  DECIMAL_ZERO = BigDecimal('0.0').freeze
+  DECIMAL_POSITIVES = BigDecimal('1.0').freeze
+  DECIMAL_NEGATIVES = BigDecimal('-1.0').freeze
+
+  context Integer do  
     describe '#to_b' do
       context 'when value is 0' do
-        subject { 0 }
+        subject { ZERO }
         it { expect(subject.to_b).to be false }
       end
 
       context 'positive values' do
-        positives.each do |value|
+        INTEGER_POSITIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
@@ -21,7 +28,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        negatives.each do |value|
+        INTEGER_NEGATIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
@@ -32,12 +39,12 @@ RSpec.describe WannabeBool::Numeric do
 
     describe '#to_bool' do
       context 'when value is 0' do
-        subject { 0 }
+        subject { ZERO }
         it { expect(subject.to_bool).to be false }
       end
 
       context 'positive values' do
-        positives.each do |value|
+        INTEGER_POSITIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_bool).to be true }
@@ -46,7 +53,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        negatives.each do |value|
+        INTEGER_NEGATIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_bool).to be true }
@@ -57,12 +64,12 @@ RSpec.describe WannabeBool::Numeric do
 
     describe '#to_boolean' do
       context 'when value is 0' do
-        subject { 0 }
+        subject { ZERO }
         it { expect(subject.to_boolean).to be false }
       end
 
       context 'positive values' do
-        positives.each do |value|
+        INTEGER_POSITIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_boolean).to be true }
@@ -71,7 +78,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        negatives.each do |value|
+        INTEGER_NEGATIVES.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_boolean).to be true }
@@ -84,51 +91,51 @@ RSpec.describe WannabeBool::Numeric do
   context Float do
     describe '#to_b' do
       context 'when value is 0.0' do
-        subject { 0.0 }
+        subject { FLOAT_ZERO }
         it { expect(subject.to_b).to be false }
       end
 
       context "when value is positive" do
-        subject { Random.rand }
+        subject { FLOAT_POSITIVES }
         it { expect(subject.to_b).to be true }
       end
 
       context "when value is negative" do
-        subject { Random.rand * -1 }
+        subject { FLOAT_NEGATIVES }
         it { expect(subject.to_b).to be true }
       end
     end
 
     describe '#to_bool' do
       context 'when value is 0.0' do
-        subject { 0.0 }
+        subject { FLOAT_ZERO }
         it { expect(subject.to_bool).to be false }
       end
 
       context "when value is positive" do
-        subject { Random.rand }
+        subject { FLOAT_POSITIVES }
         it { expect(subject.to_bool).to be true }
       end
 
       context "when value is negative" do
-        subject { Random.rand * -1 }
+        subject { FLOAT_NEGATIVES }
         it { expect(subject.to_bool).to be true }
       end
     end
 
     describe '#to_boolean' do
       context 'when value is 0.0' do
-        subject { 0.0 }
+        subject { FLOAT_ZERO }
         it { expect(subject.to_boolean).to be false }
       end
 
       context "when value is positive" do
-        subject { Random.rand }
+        subject { FLOAT_POSITIVES }
         it { expect(subject.to_boolean).to be true }
       end
 
       context "when value is negative" do
-        subject { Random.rand * -1 }
+        subject { FLOAT_NEGATIVES }
         it { expect(subject.to_boolean).to be true }
       end
     end
@@ -137,51 +144,51 @@ RSpec.describe WannabeBool::Numeric do
   context BigDecimal do
     describe '#to_b' do
       context 'when value is 0.0' do
-        subject { BigDecimal('0.0') }
+        subject { DECIMAL_ZERO }
         it { expect(subject.to_b).to be false }
       end
 
       context "when value is positive" do
-        subject { BigDecimal('1.0') }
+        subject { DECIMAL_POSITIVES }
         it { expect(subject.to_b).to be true }
       end
 
       context "when value is negative" do
-        subject { BigDecimal('-1.0') }
+        subject { DECIMAL_NEGATIVES }
         it { expect(subject.to_b).to be true }
       end
     end
 
     describe '#to_bool' do
       context 'when value is 0.0' do
-        subject { BigDecimal('0.0') }
+        subject { DECIMAL_ZERO }
         it { expect(subject.to_bool).to be false }
       end
 
       context "when value is positive" do
-        subject { BigDecimal('1.0') }
+        subject { DECIMAL_POSITIVES }
         it { expect(subject.to_bool).to be true }
       end
 
       context "when value is negative" do
-        subject { BigDecimal('-1.0') }
+        subject { DECIMAL_NEGATIVES }
         it { expect(subject.to_bool).to be true }
       end
     end
 
     describe '#to_boolean' do
       context 'when value is 0.0' do
-        subject { BigDecimal('0.0') }
+        subject { DECIMAL_ZERO }
         it { expect(subject.to_boolean).to be false }
       end
 
       context "when value is positive" do
-        subject { BigDecimal('1.0') }
+        subject { DECIMAL_POSITIVES }
         it { expect(subject.to_boolean).to be true }
       end
 
       context "when value is negative" do
-        subject { BigDecimal('-1.0') }
+        subject { DECIMAL_NEGATIVES }
         it { expect(subject.to_boolean).to be true }
       end
     end    

--- a/spec/wannabe_bool/numeric_spec.rb
+++ b/spec/wannabe_bool/numeric_spec.rb
@@ -2,6 +2,9 @@ require 'bigdecimal'
 
 RSpec.describe WannabeBool::Numeric do
   context Integer do
+    positives = (1..9)
+    negatives = (-9..-1)
+    
     describe '#to_b' do
       context 'when value is 0' do
         subject { 0 }
@@ -9,7 +12,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'positive values' do
-        (1..9).each do |value|
+        positives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
@@ -18,7 +21,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        (-9..-1).each do |value|
+        negatives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
@@ -34,7 +37,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'positive values' do
-        (1..9).each do |value|
+        positives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_bool).to be true }
@@ -43,7 +46,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        (-9..-1).each do |value|
+        negatives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_bool).to be true }
@@ -59,7 +62,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'positive values' do
-        (1..9).each do |value|
+        positives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_boolean).to be true }
@@ -68,7 +71,7 @@ RSpec.describe WannabeBool::Numeric do
       end
 
       context 'negative values' do
-        (-9..-1).each do |value|
+        negatives.each do |value|
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_boolean).to be true }

--- a/spec/wannabe_bool/numeric_spec.rb
+++ b/spec/wannabe_bool/numeric_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe WannabeBool::Numeric do
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
-            it { expect(subject.to_boolean).to be subject.to_b }
-            it { expect(subject.to_bool).to be subject.to_b }
           end
         end
       end
@@ -24,12 +22,60 @@ RSpec.describe WannabeBool::Numeric do
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
-            it { expect(subject.to_boolean).to be subject.to_b }
-            it { expect(subject.to_bool).to be subject.to_b }
           end
         end
       end
     end
+
+    describe '#to_bool' do
+      context 'when value is 0' do
+        subject { 0 }
+        it { expect(subject.to_bool).to be false }
+      end
+
+      context 'positive values' do
+        (1..9).each do |value|
+          context "when value is #{value}" do
+            subject { value }
+            it { expect(subject.to_bool).to be true }
+          end
+        end
+      end
+
+      context 'negative values' do
+        (-9..-1).each do |value|
+          context "when value is #{value}" do
+            subject { value }
+            it { expect(subject.to_bool).to be true }
+          end
+        end
+      end
+    end
+
+    describe '#to_boolean' do
+      context 'when value is 0' do
+        subject { 0 }
+        it { expect(subject.to_boolean).to be false }
+      end
+
+      context 'positive values' do
+        (1..9).each do |value|
+          context "when value is #{value}" do
+            subject { value }
+            it { expect(subject.to_boolean).to be true }
+          end
+        end
+      end
+
+      context 'negative values' do
+        (-9..-1).each do |value|
+          context "when value is #{value}" do
+            subject { value }
+            it { expect(subject.to_boolean).to be true }
+          end
+        end
+      end
+    end    
   end
 
   context Float do
@@ -37,22 +83,50 @@ RSpec.describe WannabeBool::Numeric do
       context 'when value is 0.0' do
         subject { 0.0 }
         it { expect(subject.to_b).to be false }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is positive" do
         subject { Random.rand }
         it { expect(subject.to_b).to be true }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is negative" do
         subject { Random.rand * -1 }
         it { expect(subject.to_b).to be true }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
+      end
+    end
+
+    describe '#to_bool' do
+      context 'when value is 0.0' do
+        subject { 0.0 }
+        it { expect(subject.to_bool).to be false }
+      end
+
+      context "when value is positive" do
+        subject { Random.rand }
+        it { expect(subject.to_bool).to be true }
+      end
+
+      context "when value is negative" do
+        subject { Random.rand * -1 }
+        it { expect(subject.to_bool).to be true }
+      end
+    end
+
+    describe '#to_boolean' do
+      context 'when value is 0.0' do
+        subject { 0.0 }
+        it { expect(subject.to_boolean).to be false }
+      end
+
+      context "when value is positive" do
+        subject { Random.rand }
+        it { expect(subject.to_boolean).to be true }
+      end
+
+      context "when value is negative" do
+        subject { Random.rand * -1 }
+        it { expect(subject.to_boolean).to be true }
       end
     end
   end
@@ -62,23 +136,51 @@ RSpec.describe WannabeBool::Numeric do
       context 'when value is 0.0' do
         subject { BigDecimal('0.0') }
         it { expect(subject.to_b).to be false }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is positive" do
         subject { BigDecimal('1.0') }
         it { expect(subject.to_b).to be true }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is negative" do
         subject { BigDecimal('-1.0') }
         it { expect(subject.to_b).to be true }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
       end
     end
+
+    describe '#to_bool' do
+      context 'when value is 0.0' do
+        subject { BigDecimal('0.0') }
+        it { expect(subject.to_bool).to be false }
+      end
+
+      context "when value is positive" do
+        subject { BigDecimal('1.0') }
+        it { expect(subject.to_bool).to be true }
+      end
+
+      context "when value is negative" do
+        subject { BigDecimal('-1.0') }
+        it { expect(subject.to_bool).to be true }
+      end
+    end
+
+    describe '#to_boolean' do
+      context 'when value is 0.0' do
+        subject { BigDecimal('0.0') }
+        it { expect(subject.to_boolean).to be false }
+      end
+
+      context "when value is positive" do
+        subject { BigDecimal('1.0') }
+        it { expect(subject.to_boolean).to be true }
+      end
+
+      context "when value is negative" do
+        subject { BigDecimal('-1.0') }
+        it { expect(subject.to_boolean).to be true }
+      end
+    end    
   end
 end

--- a/spec/wannabe_bool/numeric_spec.rb
+++ b/spec/wannabe_bool/numeric_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe WannabeBool::Numeric do
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
+            it { expect(subject.to_boolean).to be subject.to_b }
+            it { expect(subject.to_bool).to be subject.to_b }
           end
         end
       end
@@ -22,6 +24,8 @@ RSpec.describe WannabeBool::Numeric do
           context "when value is #{value}" do
             subject { value }
             it { expect(subject.to_b).to be true }
+            it { expect(subject.to_boolean).to be subject.to_b }
+            it { expect(subject.to_bool).to be subject.to_b }
           end
         end
       end
@@ -33,16 +37,22 @@ RSpec.describe WannabeBool::Numeric do
       context 'when value is 0.0' do
         subject { 0.0 }
         it { expect(subject.to_b).to be false }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is positive" do
         subject { Random.rand }
         it { expect(subject.to_b).to be true }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is negative" do
         subject { Random.rand * -1 }
         it { expect(subject.to_b).to be true }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
     end
   end
@@ -52,16 +62,22 @@ RSpec.describe WannabeBool::Numeric do
       context 'when value is 0.0' do
         subject { BigDecimal('0.0') }
         it { expect(subject.to_b).to be false }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is positive" do
         subject { BigDecimal('1.0') }
         it { expect(subject.to_b).to be true }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
 
       context "when value is negative" do
         subject { BigDecimal('-1.0') }
         it { expect(subject.to_b).to be true }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
     end
   end

--- a/spec/wannabe_bool/string_spec.rb
+++ b/spec/wannabe_bool/string_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe WannabeBool::String do
-  truthy_values = [ 
+  # use self:: to make the constant only available to this spec class
+  self::TRUTHY_VALUES = [ 
     '1', '1 ', ' 1', ' 1 ',
     't', 't ', ' t', ' t ',
     'T', 'T ', ' T', ' T ',
@@ -11,9 +12,9 @@ RSpec.describe WannabeBool::String do
     'Y', 'Y ', ' Y', ' Y ',
     'yes', 'yes ', ' yes', ' yes ',
     'YES', 'YES ', ' YES', ' YES '
-  ]
+  ].freeze
 
-  falsey_values = [
+  self::FALSEY_VALUES = [
     '0', '0 ', ' 0', ' 0 ',
     'f', 'f ', ' f', ' f ',
     'F', 'F ', ' F', ' F ',
@@ -25,18 +26,18 @@ RSpec.describe WannabeBool::String do
     'N', 'N ', ' N', ' N ',
     'no', 'no ', ' no', ' no ',
     'NO', 'NO ', ' NO', ' NO '
-  ]
+  ].freeze
 
-  invalid_values = [ 
+  self::INVALID_VALUES = [ 
     '', 'nil',
     '2', '-1', '-2',
     'not', 'NOT',
     'wherever', 'Prodis'
-  ]
+  ].freeze
 
   describe '#to_b' do
     context 'truthy values' do
-      truthy_values.each do |value|
+      self::TRUTHY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_b }
           it { is_expected.to be true }
@@ -45,7 +46,7 @@ RSpec.describe WannabeBool::String do
     end
 
     context 'falsey values' do
-      falsey_values.each do |value|
+      self::FALSEY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_b }
           it { is_expected.to be false }
@@ -63,7 +64,7 @@ RSpec.describe WannabeBool::String do
           WannabeBool.invalid_value_behaviour = -> { :wherever }
         end
 
-        invalid_values.each do |value|
+        self::INVALID_VALUES.each do |value|
           context "when string is '#{value}'" do
             it 'returns the result of the given behaviour' do
               expect(value.to_b).to be :wherever
@@ -76,7 +77,7 @@ RSpec.describe WannabeBool::String do
 
   describe '#to_bool' do
     context 'truthy values' do
-      truthy_values.each do |value|
+      self::TRUTHY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_bool }
           it { is_expected.to be true }
@@ -85,7 +86,7 @@ RSpec.describe WannabeBool::String do
     end
 
     context 'falsey values' do
-      falsey_values.each do |value|
+      self::FALSEY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_bool }
           it { is_expected.to be false }
@@ -103,7 +104,7 @@ RSpec.describe WannabeBool::String do
           WannabeBool.invalid_value_behaviour = -> { :wherever }
         end
 
-        invalid_values.each do |value|
+        self::INVALID_VALUES.each do |value|
           context "when string is '#{value}'" do
             it 'returns the result of the given behaviour' do
               expect(value.to_bool).to be :wherever
@@ -116,7 +117,7 @@ RSpec.describe WannabeBool::String do
 
   describe '#to_boolean' do
     context 'truthy values' do
-      truthy_values.each do |value|
+      self::TRUTHY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_boolean }
           it { is_expected.to be true }
@@ -125,7 +126,7 @@ RSpec.describe WannabeBool::String do
     end
 
     context 'falsey values' do
-      falsey_values.each do |value|
+      self::FALSEY_VALUES.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_boolean }
           it { is_expected.to be false }
@@ -143,7 +144,7 @@ RSpec.describe WannabeBool::String do
           WannabeBool.invalid_value_behaviour = -> { :wherever }
         end
 
-        invalid_values.each do |value|
+        self::INVALID_VALUES.each do |value|
           context "when string is '#{value}'" do
             it 'returns the result of the given behaviour' do
               expect(value.to_boolean).to be :wherever

--- a/spec/wannabe_bool/string_spec.rb
+++ b/spec/wannabe_bool/string_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe WannabeBool::String do
           subject { value.to_b }
           it { is_expected.to be true }
         end
+
+        context "using aliasing when string is '#{value}'" do
+          it 'should return the same value as .to_b' do
+            expect(value.to_boolean).to eq value.to_b
+          end
+
+          it 'should return the same value as .to_b' do
+            expect(value.to_b).to eq value.to_b
+          end
+        end      
       end
     end
 
@@ -37,6 +47,16 @@ RSpec.describe WannabeBool::String do
           subject { value.to_b }
           it { is_expected.to be false }
         end
+
+        context "using aliasing when string is '#{value}'" do
+          it 'should return the same value as .to_b' do
+            expect(value.to_boolean).to eq value.to_b
+          end
+
+          it 'should return the same value as .to_b' do
+            expect(value.to_b).to eq value.to_b
+          end
+        end        
       end
     end
 
@@ -58,6 +78,16 @@ RSpec.describe WannabeBool::String do
           context "when string is '#{value}'" do
             it 'returns the result of the given behaviour' do
               expect(value.to_b).to be :wherever
+            end
+          end
+
+          context "using aliasing when string is '#{value}'" do
+            it 'should return the same value as .to_b' do
+              expect(value.to_boolean).to eq value.to_b
+            end
+
+            it 'should return the same value as .to_b' do
+              expect(value.to_b).to eq value.to_b
             end
           end
         end

--- a/spec/wannabe_bool/string_spec.rb
+++ b/spec/wannabe_bool/string_spec.rb
@@ -1,62 +1,55 @@
 RSpec.describe WannabeBool::String do
+  truthy_values = [ 
+    '1', '1 ', ' 1', ' 1 ',
+    't', 't ', ' t', ' t ',
+    'T', 'T ', ' T', ' T ',
+    'true', 'true ', ' true', ' true ',
+    'TRUE', 'TRUE ', ' TRUE', ' TRUE ',
+    'on', 'on ', ' on', ' on ',
+    'ON', 'ON ', ' ON ', ' ON ',
+    'y', 'y ', ' y', ' y ',
+    'Y', 'Y ', ' Y', ' Y ',
+    'yes', 'yes ', ' yes', ' yes ',
+    'YES', 'YES ', ' YES', ' YES '
+  ]
+
+  falsey_values = [
+    '0', '0 ', ' 0', ' 0 ',
+    'f', 'f ', ' f', ' f ',
+    'F', 'F ', ' F', ' F ',
+    'false', 'false ', ' false', ' false ',
+    'FALSE', 'FALSE ', ' FALSE', ' FALSE ',
+    'off', 'off ', ' off', ' off ',
+    'OFF', 'OFF ', ' OFF ', ' OFF ',
+    'n', 'n ', ' n', ' n ',
+    'N', 'N ', ' N', ' N ',
+    'no', 'no ', ' no', ' no ',
+    'NO', 'NO ', ' NO', ' NO '
+  ]
+
+  invalid_values = [ 
+    '', 'nil',
+    '2', '-1', '-2',
+    'not', 'NOT',
+    'wherever', 'Prodis'
+  ]
+
   describe '#to_b' do
     context 'truthy values' do
-      [ '1', '1 ', ' 1', ' 1 ',
-        't', 't ', ' t', ' t ',
-        'T', 'T ', ' T', ' T ',
-        'true', 'true ', ' true', ' true ',
-        'TRUE', 'TRUE ', ' TRUE', ' TRUE ',
-        'on', 'on ', ' on', ' on ',
-        'ON', 'ON ', ' ON ', ' ON ',
-        'y', 'y ', ' y', ' y ',
-        'Y', 'Y ', ' Y', ' Y ',
-        'yes', 'yes ', ' yes', ' yes ',
-        'YES', 'YES ', ' YES', ' YES '
-      ].each do |value|
+      truthy_values.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_b }
           it { is_expected.to be true }
-        end
-
-        context "using aliasing when string is '#{value}'" do
-          it 'should return the same value as .to_b' do
-            expect(value.to_boolean).to eq value.to_b
-          end
-
-          it 'should return the same value as .to_b' do
-            expect(value.to_b).to eq value.to_b
-          end
-        end      
+        end    
       end
     end
 
     context 'falsey values' do
-      [ '0', '0 ', ' 0', ' 0 ',
-        'f', 'f ', ' f', ' f ',
-        'F', 'F ', ' F', ' F ',
-        'false', 'false ', ' false', ' false ',
-        'FALSE', 'FALSE ', ' FALSE', ' FALSE ',
-        'off', 'off ', ' off', ' off ',
-        'OFF', 'OFF ', ' OFF ', ' OFF ',
-        'n', 'n ', ' n', ' n ',
-        'N', 'N ', ' N', ' N ',
-        'no', 'no ', ' no', ' no ',
-        'NO', 'NO ', ' NO', ' NO '
-      ].each do |value|
+      falsey_values.each do |value|
         context "when string is '#{value}'" do
           subject { value.to_b }
           it { is_expected.to be false }
-        end
-
-        context "using aliasing when string is '#{value}'" do
-          it 'should return the same value as .to_b' do
-            expect(value.to_boolean).to eq value.to_b
-          end
-
-          it 'should return the same value as .to_b' do
-            expect(value.to_b).to eq value.to_b
-          end
-        end        
+        end      
       end
     end
 
@@ -70,28 +63,94 @@ RSpec.describe WannabeBool::String do
           WannabeBool.invalid_value_behaviour = -> { :wherever }
         end
 
-        [ '', 'nil',
-          '2', '-1', '-2',
-          'not', 'NOT',
-          'wherever', 'Prodis'
-        ].each do |value|
+        invalid_values.each do |value|
           context "when string is '#{value}'" do
             it 'returns the result of the given behaviour' do
               expect(value.to_b).to be :wherever
-            end
-          end
-
-          context "using aliasing when string is '#{value}'" do
-            it 'should return the same value as .to_b' do
-              expect(value.to_boolean).to eq value.to_b
-            end
-
-            it 'should return the same value as .to_b' do
-              expect(value.to_b).to eq value.to_b
             end
           end
         end
       end
     end
   end
+
+  describe '#to_bool' do
+    context 'truthy values' do
+      truthy_values.each do |value|
+        context "when string is '#{value}'" do
+          subject { value.to_bool }
+          it { is_expected.to be true }
+        end    
+      end
+    end
+
+    context 'falsey values' do
+      falsey_values.each do |value|
+        context "when string is '#{value}'" do
+          subject { value.to_bool }
+          it { is_expected.to be false }
+        end      
+      end
+    end
+
+    context 'invalid values' do
+      after do
+        WannabeBool.invalid_value_behaviour = WannabeBool::InvalidValueBehaviour::False
+      end
+
+      context 'when an invalid value behaviour is given' do
+        before do
+          WannabeBool.invalid_value_behaviour = -> { :wherever }
+        end
+
+        invalid_values.each do |value|
+          context "when string is '#{value}'" do
+            it 'returns the result of the given behaviour' do
+              expect(value.to_bool).to be :wherever
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#to_boolean' do
+    context 'truthy values' do
+      truthy_values.each do |value|
+        context "when string is '#{value}'" do
+          subject { value.to_boolean }
+          it { is_expected.to be true }
+        end    
+      end
+    end
+
+    context 'falsey values' do
+      falsey_values.each do |value|
+        context "when string is '#{value}'" do
+          subject { value.to_boolean }
+          it { is_expected.to be false }
+        end      
+      end
+    end
+
+    context 'invalid values' do
+      after do
+        WannabeBool.invalid_value_behaviour = WannabeBool::InvalidValueBehaviour::False
+      end
+
+      context 'when an invalid value behaviour is given' do
+        before do
+          WannabeBool.invalid_value_behaviour = -> { :wherever }
+        end
+
+        invalid_values.each do |value|
+          context "when string is '#{value}'" do
+            it 'returns the result of the given behaviour' do
+              expect(value.to_boolean).to be :wherever
+            end
+          end
+        end
+      end
+    end
+  end   
 end

--- a/spec/wannabe_bool/symbol_spec.rb
+++ b/spec/wannabe_bool/symbol_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe WannabeBool::Symbol do
       context "when symbol is '#{value}'" do
         subject { value }
         it { expect(subject.to_b).to be true }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }
       end
     end
 
@@ -31,6 +33,8 @@ RSpec.describe WannabeBool::Symbol do
       context "when symbol is '#{value}'" do
         subject { value }
         it { expect(subject.to_b).to be false }
+        it { expect(subject.to_boolean).to be subject.to_b }
+        it { expect(subject.to_bool).to be subject.to_b }        
       end
     end
   end

--- a/spec/wannabe_bool/symbol_spec.rb
+++ b/spec/wannabe_bool/symbol_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe WannabeBool::Symbol do
-  truthy_values = [ 
+  # use self:: to make the constant only available to this spec class
+  self::TRUTHY_VALUES = [ 
     :'1', :'1 ', :' 1 ', :' 1',
     :t, :'t ', :' t', :' t ',
     :T, :'T ', :' T', :' T ',
@@ -11,9 +12,9 @@ RSpec.describe WannabeBool::Symbol do
     :Y, :'Y ', :' Y', :' Y ',
     :yes, :'yes ', :' yes', :' yes ',
     :YES, :'YES ', :' YES', :' YES '
-  ]
+  ].freeze
 
-  falsey_values = [
+  self::FALSEY_VALUES = [
     :'',
     :'0', :'2', :'-1', :'-2',
     :f, :F,
@@ -23,16 +24,16 @@ RSpec.describe WannabeBool::Symbol do
     :no, :NO,
     :not, :NOT,
     :wherever, :Prodis
-  ]
+  ].freeze
 
   describe '#to_b' do
-    truthy_values.each do |value|
+    self::TRUTHY_VALUES.each do |value|
       it "should return true when symbol is '#{value}'" do
         expect(value.to_b).to eq true
       end
     end
 
-    falsey_values.each do |value|
+    self::FALSEY_VALUES.each do |value|
       it "should return false when symbol is '#{value}'" do
         expect(value.to_b).to eq false
       end
@@ -40,13 +41,13 @@ RSpec.describe WannabeBool::Symbol do
   end
 
   describe '#to_bool' do
-    truthy_values.each do |value|
+    self::TRUTHY_VALUES.each do |value|
       it "should return true when symbol is '#{value}'" do
         expect(value.to_bool).to eq true
       end
     end
 
-    falsey_values.each do |value|
+    self::FALSEY_VALUES.each do |value|
       it "should return false when symbol is '#{value}'" do
         expect(value.to_bool).to eq false
       end
@@ -54,13 +55,13 @@ RSpec.describe WannabeBool::Symbol do
   end
 
   describe '#to_boolean' do
-    truthy_values.each do |value|
+    self::TRUTHY_VALUES.each do |value|
       it "should return true when symbol is '#{value}'" do
         expect(value.to_boolean).to eq true
       end
     end
 
-    falsey_values.each do |value|
+    self::FALSEY_VALUES.each do |value|
       it "should return false when symbol is '#{value}'" do
         expect(value.to_boolean).to eq false
       end

--- a/spec/wannabe_bool/symbol_spec.rb
+++ b/spec/wannabe_bool/symbol_spec.rb
@@ -1,41 +1,69 @@
 RSpec.describe WannabeBool::Symbol do
+  truthy_values = [ 
+    :'1', :'1 ', :' 1 ', :' 1',
+    :t, :'t ', :' t', :' t ',
+    :T, :'T ', :' T', :' T ',
+    :true, :'true ', :' true', :' true ',
+    :TRUE, :'TRUE ', :' TRUE', :' TRUE ',
+    :on, :'on ', :' on', :' on ',
+    :ON, :'ON ', :' ON ', :' ON ',
+    :y, :'y ', :' y', :' y ',
+    :Y, :'Y ', :' Y', :' Y ',
+    :yes, :'yes ', :' yes', :' yes ',
+    :YES, :'YES ', :' YES', :' YES '
+  ]
+
+  falsey_values = [
+    :'',
+    :'0', :'2', :'-1', :'-2',
+    :f, :F,
+    :false, :FALSE,
+    :off, :OFF,
+    :n, :N,
+    :no, :NO,
+    :not, :NOT,
+    :wherever, :Prodis
+  ]
+
   describe '#to_b' do
-    [ :'1', :'1 ', :' 1 ', :' 1',
-      :t, :'t ', :' t', :' t ',
-      :T, :'T ', :' T', :' T ',
-      :true, :'true ', :' true', :' true ',
-      :TRUE, :'TRUE ', :' TRUE', :' TRUE ',
-      :on, :'on ', :' on', :' on ',
-      :ON, :'ON ', :' ON ', :' ON ',
-      :y, :'y ', :' y', :' y ',
-      :Y, :'Y ', :' Y', :' Y ',
-      :yes, :'yes ', :' yes', :' yes ',
-      :YES, :'YES ', :' YES', :' YES '
-    ].each do |value|
-      context "when symbol is '#{value}'" do
-        subject { value }
-        it { expect(subject.to_b).to be true }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }
+    truthy_values.each do |value|
+      it "should return true when symbol is '#{value}'" do
+        expect(value.to_b).to eq true
       end
     end
 
-    [ :'',
-      :'0', :'2', :'-1', :'-2',
-      :f, :F,
-      :false, :FALSE,
-      :off, :OFF,
-      :n, :N,
-      :no, :NO,
-      :not, :NOT,
-      :wherever, :Prodis
-    ].each do |value|
-      context "when symbol is '#{value}'" do
-        subject { value }
-        it { expect(subject.to_b).to be false }
-        it { expect(subject.to_boolean).to be subject.to_b }
-        it { expect(subject.to_bool).to be subject.to_b }        
+    falsey_values.each do |value|
+      it "should return false when symbol is '#{value}'" do
+        expect(value.to_b).to eq false
       end
     end
   end
+
+  describe '#to_bool' do
+    truthy_values.each do |value|
+      it "should return true when symbol is '#{value}'" do
+        expect(value.to_bool).to eq true
+      end
+    end
+
+    falsey_values.each do |value|
+      it "should return false when symbol is '#{value}'" do
+        expect(value.to_bool).to eq false
+      end
+    end
+  end
+
+  describe '#to_boolean' do
+    truthy_values.each do |value|
+      it "should return true when symbol is '#{value}'" do
+        expect(value.to_boolean).to eq true
+      end
+    end
+
+    falsey_values.each do |value|
+      it "should return false when symbol is '#{value}'" do
+        expect(value.to_boolean).to eq false
+      end
+    end
+  end  
 end


### PR DESCRIPTION
Add aliasing for .to_b method to all classes

For the sake of readability and personal choice