### PR TITLE
Detecting if Rails is available on the bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,9 @@ require 'bundler/setup'
 require 'wannabe_bool'
 
 require 'pry'
-Pry.start if defined?(Pry)
+if defined?(Pry)
+  Pry.start 
+else
+  require 'irb'
+  IRB.start
+end

--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,4 @@ require 'bundler/setup'
 require 'wannabe_bool'
 
 require 'pry'
-Pry.start
+Pry.start if defined?(Pry)


### PR DESCRIPTION
This PR detects if Rails is available before attempting to start the rails console in production.